### PR TITLE
feat: Add Apple Intel and Windows ARM build configurations

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest, windows-arm-latest]
         build_type: [Release, Debug]
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This commit updates the GitHub workflow to include:
- macOS 12 for Apple Intel builds.
- A placeholder for Windows ARM builds (`windows-arm-latest`), which may require further configuration for self-hosted runners.

The `os` matrix in `.github/workflows/conan.yml` has been updated accordingly.


### Summary
Changes to recipe:  **lib/[version]**

#### Motivation
<!-- Please explain why this PR is needed, if it is a bugfix, please describe the bug or link to an existing issue. -->

#### Details
<!-- Explanation of the changes in the PR - this greatly simplifies the task of the reviewing team! -->


---
- [ ] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [ ] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [ ] Tested locally with at least one configuration using a recent version of Conan
