### PR TITLE
Set minumum macOS deployment target to 13.0

### DIFF
--- a/.github/profiles/macos-latest-armv8.conanprofile
+++ b/.github/profiles/macos-latest-armv8.conanprofile
@@ -6,4 +6,4 @@ compiler.cppstd=17
 compiler.libcxx=libc++
 compiler.version=15
 os=Macos
-
+os.version=13.0

--- a/.github/profiles/macos-latest-x86_64.conanprofile
+++ b/.github/profiles/macos-latest-x86_64.conanprofile
@@ -6,4 +6,4 @@ compiler.cppstd=17
 compiler.libcxx=libc++
 compiler.version=15
 os=Macos
-
+os.version=13.0


### PR DESCRIPTION
This prevents libraries to be build targeting a newer OS version, preventing linking with Qt and the desktop client.